### PR TITLE
Remove unused intl import

### DIFF
--- a/lib/database_helper.dart
+++ b/lib/database_helper.dart
@@ -1,6 +1,5 @@
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
-import 'package:intl/intl.dart';
 
 
 class DatabaseHelper {


### PR DESCRIPTION
## Summary
- tidy imports in `database_helper.dart`

## Testing
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*

------
https://chatgpt.com/codex/tasks/task_e_683fd82a5ba08323a929cdd3d97bd4bb