### PR TITLE
Fix sqflite_common_ffi version for Dart 3.5

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -212,10 +212,10 @@ packages:
     dependency: "direct dev"
     description:
       name: sqflite_common_ffi
-      sha256: "1f3ef3888d3bfbb47785cc1dda0dc7dd7ebd8c1955d32a9e8e9dae1e38d1c4c1"
+      sha256: "883dd810b2b49e6e8c3b980df1829ef550a94e3f87deab5d864917d27ca6bf36"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.5"
+    version: "2.3.4+4"
   sqflite_darwin:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  sqflite_common_ffi: ^2.3.5
+  sqflite_common_ffi: ^2.3.4+4
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
## Summary
- fix dependency version conflict by downgrading `sqflite_common_ffi`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdd1b16a483238cf564a2d5fa6e3c