### PR TITLE
Add expense forecasting

### DIFF
--- a/lib/add_edit_expense_screen.dart
+++ b/lib/add_edit_expense_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'database_helper.dart';
+import 'package:intl/intl.dart';
 
 class AddEditExpenseScreen extends StatefulWidget {
   const AddEditExpenseScreen({super.key});
@@ -129,7 +130,7 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
                     onPressed: () async {
                       final selectedDate = await showDatePicker(
                         context: context,
-                        initialDate: DateTime.now(),
+                        initialDate: _selectedDate ?? DateTime.now(),
                         firstDate: DateTime(2000),
                         lastDate: DateTime(2100),
                       );
@@ -139,12 +140,15 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
                         });
                       }
                     },
-                    child: Text(
-                      _selectedDate == null
-                          ? 'Select Date'
-                          : 'Selected: ${_selectedDate!.toLocal()}'.split(' ')[0],
-                    ),
+                    child: const Text('Select Date'),
                   ),
+                  if (_selectedDate != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: Text(
+                        'Selected: ' + DateFormat('yyyy-MM-dd').format(_selectedDate!),
+                      ),
+                    ),
                   const SizedBox(height: 16),
                   ElevatedButton(
                     onPressed: () async {


### PR DESCRIPTION
## Summary
- analyze monthly totals to predict next month's expense
- show most expensive categories first
- display predicted next month total on home screen
- show selected date under date picker on Add/Edit screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe0d1254083239fe60ac69df00424