### PR TITLE
Dispose controllers

### DIFF
--- a/lib/add_edit_expense_screen.dart
+++ b/lib/add_edit_expense_screen.dart
@@ -27,6 +27,13 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
     _fetchExpenses();
   }
 
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _amountController.dispose();
+    super.dispose();
+  }
+
   Future<void> _fetchCategories() async {
     final data = await _dbHelper.queryAll('categories');
     setState(() {

--- a/lib/manage_categories_screen.dart
+++ b/lib/manage_categories_screen.dart
@@ -20,6 +20,12 @@ class _ManageCategoriesScreenState extends State<ManageCategoriesScreen> {
     _fetchCategories();
   }
 
+  @override
+  void dispose() {
+    _categoryController.dispose();
+    super.dispose();
+  }
+
   Future<void> _fetchCategories() async {
     final data = await _dbHelper.queryAll('categories');
     setState(() {


### PR DESCRIPTION
## Summary
- dispose text controllers in AddEditExpenseScreen
- dispose category controller in ManageCategoriesScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffbbe76688323a49ebb3ada8c51b1