### PR TITLE
Show category names for expenses

### DIFF
--- a/lib/add_edit_expense_screen.dart
+++ b/lib/add_edit_expense_screen.dart
@@ -45,7 +45,14 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
   }
 
   Future<void> _fetchExpenses() async {
-    final data = await _dbHelper.queryAll('expenses');
+    final data = await _dbHelper.rawQuery(
+      '''
+      SELECT e.id, e.name, e.category_id, e.amount, e.date, c.name AS category_name
+      FROM expenses e
+      INNER JOIN categories c ON e.category_id = c.id
+      ''',
+      [],
+    );
     setState(() {
       expenses = data;
     });
@@ -220,7 +227,7 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
                   final expense = expenses[index];
                   return ListTile(
                     title: Text('${expense['name']}'),
-                    subtitle: Text('${expense['date']} - Category ID: ${expense['category_id']}'),
+                    subtitle: Text('${expense['date']} - ${expense['category_name']}'),
                     trailing: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [


### PR DESCRIPTION
## Summary
- query expense table with category join to get `category_name`
- display the expense's date with its category name

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffc586e088323a60784db94423008