### PR TITLE
Add date filtering to expenses screen

### DIFF
--- a/lib/add_edit_expense_screen.dart
+++ b/lib/add_edit_expense_screen.dart
@@ -18,13 +18,16 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
   final DatabaseHelper _dbHelper = DatabaseHelper();
   List<Map<String, dynamic>> categories = [];
   List<Map<String, dynamic>> expenses = [];
+  String _filterOption = 'All';
+  DateTime? _filterStartDate;
+  DateTime? _filterEndDate;
   int? _selectedExpenseId;
 
   @override
   void initState() {
     super.initState();
     _fetchCategories();
-    _fetchExpenses();
+    _applyFilter();
   }
 
   @override
@@ -44,14 +47,23 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
     });
   }
 
-  Future<void> _fetchExpenses() async {
+  Future<void> _fetchExpenses({DateTime? startDate, DateTime? endDate}) async {
+    String whereClause = '';
+    List<dynamic> args = [];
+    if (startDate != null && endDate != null) {
+      whereClause = 'WHERE e.date BETWEEN ? AND ?';
+      args = [startDate.toIso8601String(), endDate.toIso8601String()];
+    }
+
     final data = await _dbHelper.rawQuery(
       '''
       SELECT e.id, e.name, e.category_id, e.amount, e.date, c.name AS category_name
       FROM expenses e
       INNER JOIN categories c ON e.category_id = c.id
+      $whereClause
+      ORDER BY e.date DESC
       ''',
-      [],
+      args,
     );
     setState(() {
       expenses = data;
@@ -60,10 +72,44 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
 
   Future<void> _deleteExpense(int id) async {
     await _dbHelper.delete('expenses', 'id = ?', [id]);
-    _fetchExpenses();
+    _applyFilter();
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Expense deleted successfully!')),
     );
+  }
+
+  Future<void> _applyFilter() async {
+    if (_filterOption == 'All') {
+      await _fetchExpenses();
+      return;
+    }
+
+    DateTime now = DateTime.now();
+    DateTime start;
+    DateTime end;
+
+    if (_filterOption == 'This Week') {
+      final int weekday = now.weekday;
+      start = now.subtract(Duration(days: weekday - 1));
+      end = start.add(const Duration(days: 6));
+    } else if (_filterOption == 'This Month') {
+      start = DateTime(now.year, now.month, 1);
+      end = DateTime(now.year, now.month + 1, 0);
+    } else if (_filterOption == 'Date Range') {
+      if (_filterStartDate == null || _filterEndDate == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Please select start and end dates')),
+        );
+        return;
+      }
+      start = _filterStartDate!;
+      end = _filterEndDate!;
+    } else {
+      await _fetchExpenses();
+      return;
+    }
+
+    await _fetchExpenses(startDate: start, endDate: end);
   }
 
   void _populateForm(Map<String, dynamic> expense) {
@@ -204,7 +250,7 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
                                 const SnackBar(content: Text('Expense updated successfully!')),
                               );
                             }
-                            _fetchExpenses();
+                            _applyFilter();
                             _nameController.clear();
                             _amountController.clear();
                             setState(() {
@@ -222,6 +268,87 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
                       ),
                     ],
                   ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Card(
+              elevation: 2,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  children: [
+                    DropdownButton<String>(
+                      value: _filterOption,
+                      items: const [
+                        DropdownMenuItem(value: 'All', child: Text('All')),
+                        DropdownMenuItem(value: 'This Week', child: Text('This Week')),
+                        DropdownMenuItem(value: 'This Month', child: Text('This Month')),
+                        DropdownMenuItem(value: 'Date Range', child: Text('Date Range')),
+                      ],
+                      onChanged: (value) {
+                        if (value == null) return;
+                        setState(() {
+                          _filterOption = value;
+                        });
+                        if (value != 'Date Range') {
+                          _filterStartDate = null;
+                          _filterEndDate = null;
+                          _applyFilter();
+                        }
+                      },
+                    ),
+                    if (_filterOption == 'Date Range')
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          TextButton(
+                            onPressed: () async {
+                              final date = await showDatePicker(
+                                context: context,
+                                initialDate: _filterStartDate ?? DateTime.now(),
+                                firstDate: DateTime(2000),
+                                lastDate: DateTime(2100),
+                              );
+                              if (date != null) {
+                                setState(() {
+                                  _filterStartDate = date;
+                                });
+                              }
+                            },
+                            child: Text(
+                              _filterStartDate == null
+                                  ? 'Start Date'
+                                  : DateFormat('yyyy-MM-dd').format(_filterStartDate!),
+                            ),
+                          ),
+                          TextButton(
+                            onPressed: () async {
+                              final date = await showDatePicker(
+                                context: context,
+                                initialDate: _filterEndDate ?? DateTime.now(),
+                                firstDate: DateTime(2000),
+                                lastDate: DateTime(2100),
+                              );
+                              if (date != null) {
+                                setState(() {
+                                  _filterEndDate = date;
+                                });
+                              }
+                            },
+                            child: Text(
+                              _filterEndDate == null
+                                  ? 'End Date'
+                                  : DateFormat('yyyy-MM-dd').format(_filterEndDate!),
+                            ),
+                          ),
+                          ElevatedButton(
+                            onPressed: _applyFilter,
+                            child: const Text('Apply'),
+                          ),
+                        ],
+                      ),
+                  ],
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- enable filtering expenses by week, month, or custom date range
- apply chosen filters when adding, editing, or deleting expenses

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495126484c8323bc9222684847fcfb