### PR TITLE
Add date filtering to expenses screen

### DIFF
--- a/lib/add_edit_expense_screen.dart
+++ b/lib/add_edit_expense_screen.dart
@@ -18,13 +18,16 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
   final DatabaseHelper _dbHelper = DatabaseHelper();
   List<Map<String, dynamic>> categories = [];
   List<Map<String, dynamic>> expenses = [];
+  String _filterOption = 'All';
+  DateTime? _filterStartDate;
+  DateTime? _filterEndDate;
   int? _selectedExpenseId;
 
   @override
   void initState() {
     super.initState();
     _fetchCategories();
-    _fetchExpenses();
+    _applyFilter();
   }
 
   @override
@@ -44,14 +47,23 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
     });
   }
 
-  Future<void> _fetchExpenses() async {
+  Future<void> _fetchExpenses({DateTime? startDate, DateTime? endDate}) async {
+    String whereClause = '';
+    List<dynamic> args = [];
+    if (startDate != null && endDate != null) {
+      whereClause = 'WHERE e.date BETWEEN ? AND ?';
+      args = [startDate.toIso8601String(), endDate.toIso8601String()];
+    }
+
     final data = await _dbHelper.rawQuery(
       '''
       SELECT e.id, e.name, e.category_id, e.amount, e.date, c.name AS category_name
       FROM expenses e
       INNER JOIN categories c ON e.category_id = c.id
+      $whereClause
+      ORDER BY e.date DESC
       ''',
-      [],
+      args,
     );
     setState(() {
       expenses = data;
@@ -60,10 +72,51 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
 
   Future<void> _deleteExpense(int id) async {
     await _dbHelper.delete('expenses', 'id = ?', [id]);
-    _fetchExpenses();
+    _applyFilter();
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Expense deleted successfully!')),
     );
+  }
+
+  Future<void> _applyFilter() async {
+    if (_filterOption == 'All') {
+      await _fetchExpenses();
+      return;
+    }
+
+    DateTime now = DateTime.now();
+    late DateTime start;
+    late DateTime end;
+
+    if (_filterOption == 'This Week') {
+      final int weekday = now.weekday;
+      start = now.subtract(Duration(days: weekday - 1));
+      end = start.add(const Duration(days: 6));
+    } else if (_filterOption == 'Last Week') {
+      final int weekday = now.weekday;
+      end = now.subtract(Duration(days: weekday));
+      start = end.subtract(const Duration(days: 6));
+    } else if (_filterOption == 'This Month') {
+      start = DateTime(now.year, now.month, 1);
+      end = DateTime(now.year, now.month + 1, 0);
+    } else if (_filterOption == 'Last Month') {
+      start = DateTime(now.year, now.month - 1, 1);
+      end = DateTime(now.year, now.month, 0);
+    } else if (_filterOption == 'Date Range') {
+      if (_filterStartDate == null || _filterEndDate == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Please select start and end dates')),
+        );
+        return;
+      }
+      start = _filterStartDate!;
+      end = _filterEndDate!;
+    } else {
+      await _fetchExpenses();
+      return;
+    }
+
+    await _fetchExpenses(startDate: start, endDate: end);
   }
 
   void _populateForm(Map<String, dynamic> expense) {
@@ -204,7 +257,7 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
                                 const SnackBar(content: Text('Expense updated successfully!')),
                               );
                             }
-                            _fetchExpenses();
+                            _applyFilter();
                             _nameController.clear();
                             _amountController.clear();
                             setState(() {
@@ -226,6 +279,89 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
               ),
             ),
             const SizedBox(height: 16),
+            Card(
+              elevation: 2,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  children: [
+                    DropdownButton<String>(
+                      value: _filterOption,
+                      items: const [
+                        DropdownMenuItem(value: 'All', child: Text('All')),
+                        DropdownMenuItem(value: 'This Week', child: Text('This Week')),
+                        DropdownMenuItem(value: 'Last Week', child: Text('Last Week')),
+                        DropdownMenuItem(value: 'This Month', child: Text('This Month')),
+                        DropdownMenuItem(value: 'Last Month', child: Text('Last Month')),
+                        DropdownMenuItem(value: 'Date Range', child: Text('Date Range')),
+                      ],
+                      onChanged: (value) {
+                        if (value == null) return;
+                        setState(() {
+                          _filterOption = value;
+                        });
+                        if (value != 'Date Range') {
+                          _filterStartDate = null;
+                          _filterEndDate = null;
+                          _applyFilter();
+                        }
+                      },
+                    ),
+                    if (_filterOption == 'Date Range')
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          TextButton(
+                            onPressed: () async {
+                              final date = await showDatePicker(
+                                context: context,
+                                initialDate: _filterStartDate ?? DateTime.now(),
+                                firstDate: DateTime(2000),
+                                lastDate: DateTime(2100),
+                              );
+                              if (date != null) {
+                                setState(() {
+                                  _filterStartDate = date;
+                                });
+                              }
+                            },
+                            child: Text(
+                              _filterStartDate == null
+                                  ? 'Start Date'
+                                  : DateFormat('yyyy-MM-dd').format(_filterStartDate!),
+                            ),
+                          ),
+                          TextButton(
+                            onPressed: () async {
+                              final date = await showDatePicker(
+                                context: context,
+                                initialDate: _filterEndDate ?? DateTime.now(),
+                                firstDate: DateTime(2000),
+                                lastDate: DateTime(2100),
+                              );
+                              if (date != null) {
+                                setState(() {
+                                  _filterEndDate = date;
+                                });
+                              }
+                            },
+                            child: Text(
+                              _filterEndDate == null
+                                  ? 'End Date'
+                                  : DateFormat('yyyy-MM-dd').format(_filterEndDate!),
+                            ),
+                          ),
+                          ElevatedButton(
+                            onPressed: _applyFilter,
+                            child: const Text('Apply'),
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
             Expanded(
               child: ListView.builder(
                 itemCount: expenses.length,
@@ -235,7 +371,8 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
                     margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     child: ListTile(
                       title: Text('${expense['name']} - Rs. ${expense['amount']}'),
-                      subtitle: Text('${expense['date']} - ${expense['category_name']}'),
+                      subtitle: Text(
+                          '${DateFormat('yyyy-MM-dd').format(DateTime.parse(expense['date']))} - ${expense['category_name']}'),
                       trailing: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [

--- a/lib/database_helper.dart
+++ b/lib/database_helper.dart
@@ -89,4 +89,14 @@ class DatabaseHelper {
     
     return (result.first['total_amount'] as num?)?.toDouble() ?? 0.0;
   }
+
+  Future<List<Map<String, dynamic>>> queryExpensesByDate() async {
+    final db = await database;
+    return await db.rawQuery('''
+      SELECT date(date) AS date, SUM(amount) AS total_amount
+      FROM expenses
+      GROUP BY date(date)
+      ORDER BY date(date)
+    ''');
+  }
 }

--- a/lib/expenses_chart_screen.dart
+++ b/lib/expenses_chart_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:intl/intl.dart';
+import 'database_helper.dart';
+
+class ExpensesChartScreen extends StatefulWidget {
+  const ExpensesChartScreen({super.key});
+
+  @override
+  State<ExpensesChartScreen> createState() => _ExpensesChartScreenState();
+}
+
+class _ExpensesChartScreenState extends State<ExpensesChartScreen> {
+  final DatabaseHelper _dbHelper = DatabaseHelper();
+  List<Map<String, dynamic>> _dailyExpenses = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchDailyExpenses();
+  }
+
+  Future<void> _fetchDailyExpenses() async {
+    final data = await _dbHelper.queryExpensesByDate();
+    setState(() {
+      _dailyExpenses = data;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final barGroups = <BarChartGroupData>[];
+    final labels = <int, String>{};
+    for (var i = 0; i < _dailyExpenses.length; i++) {
+      final row = _dailyExpenses[i];
+      final amount = (row['total_amount'] as num?)?.toDouble() ?? 0.0;
+      barGroups.add(
+        BarChartGroupData(x: i, barRods: [
+          BarChartRodData(toY: amount, color: Colors.indigo, width: 12),
+        ]),
+      );
+      labels[i] = DateFormat('MM/dd').format(DateTime.parse(row['date'] as String));
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Expenses Over Time')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: _dailyExpenses.isEmpty
+            ? const Center(child: Text('No data'))
+            : BarChart(
+                BarChartData(
+                  barGroups: barGroups,
+                  gridData: FlGridData(show: false),
+                  titlesData: FlTitlesData(
+                    leftTitles: const AxisTitles(
+                      sideTitles: SideTitles(showTitles: true),
+                    ),
+                    rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                    topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                    bottomTitles: AxisTitles(
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        getTitlesWidget: (double value, TitleMeta meta) {
+                          final label = labels[value.toInt()] ?? '';
+                          return SideTitleWidget(
+                            axisSide: meta.axisSide,
+                            child: Text(label, style: const TextStyle(fontSize: 10)),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'database_helper.dart';
+import 'package:intl/intl.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -193,6 +194,15 @@ class _HomeScreenState extends State<HomeScreen> {
             child: const Icon(Icons.category),
             tooltip: 'Manage Categories',
           ),
+          const SizedBox(height: 16),
+          FloatingActionButton(
+            heroTag: 'view_chart',
+            onPressed: () async {
+              await Navigator.pushNamed(context, '/expenses_chart');
+            },
+            child: const Icon(Icons.bar_chart),
+            tooltip: 'View Chart',
+          ),
         ],
       ),
     );
@@ -221,7 +231,8 @@ class ExpensesForCategoryScreen extends StatelessWidget {
             margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
             child: ListTile(
               title: Text('${expense['name']}'),
-              subtitle: Text('${expense['date']}'),
+              subtitle: Text(
+                  DateFormat('yyyy-MM-dd').format(DateTime.parse(expense['date']))),
               trailing: Text('Rs${expense['amount']}'),
             ),
           );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'home_screen.dart';
 import 'add_edit_expense_screen.dart';
 import 'manage_categories_screen.dart';
+import 'expenses_chart_screen.dart';
 
 void main() => runApp(const ExpenseTrackerApp());
 
@@ -23,6 +24,7 @@ class ExpenseTrackerApp extends StatelessWidget {
         '/': (context) => const HomeScreen(),
         '/add_edit_expense': (context) => const AddEditExpenseScreen(),
         '/manage_categories': (context) => const ManageCategoriesScreen(),
+        '/expenses_chart': (context) => const ExpensesChartScreen(),
       },
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   path: ^1.8.0
   intl: ^0.18.0
   google_fonts: ^6.2.1
+  fl_chart: ^0.64.0
 
 
 


### PR DESCRIPTION
## Summary
- enable filtering expenses by week, last week, month, last month, or custom date range
- apply chosen filters when adding, editing, or deleting expenses
- show date in lists without time component
- display daily totals graph on new chart screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495126484c8323bc9222684847fcfb