### PR TITLE
Add total calculation for filtered expenses

### DIFF
--- a/lib/add_edit_expense_screen.dart
+++ b/lib/add_edit_expense_screen.dart
@@ -18,6 +18,7 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
   final DatabaseHelper _dbHelper = DatabaseHelper();
   List<Map<String, dynamic>> categories = [];
   List<Map<String, dynamic>> expenses = [];
+  double _totalAmount = 0.0;
   String _filterOption = 'All';
   DateTime? _filterStartDate;
   DateTime? _filterEndDate;
@@ -65,8 +66,13 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
       ''',
       args,
     );
+    double sum = 0.0;
+    for (final row in data) {
+      sum += (row['amount'] as num?)?.toDouble() ?? 0.0;
+    }
     setState(() {
       expenses = data;
+      _totalAmount = sum;
     });
   }
 
@@ -351,12 +357,22 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
                                   : DateFormat('yyyy-MM-dd').format(_filterEndDate!),
                             ),
                           ),
-                          ElevatedButton(
+                      ElevatedButton(
                             onPressed: _applyFilter,
                             child: const Text('Apply'),
                           ),
                         ],
                       ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'Total: Rs${_totalAmount.toStringAsFixed(2)}',
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                    ),
                   ],
                 ),
               ),


### PR DESCRIPTION
## Summary
- compute total amount when filtering expenses
- display total under the date range filter

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a03184cc08323aa980792a1d04c4b