### PR TITLE
Enable date range filtering on charts

### DIFF
--- a/lib/add_edit_expense_screen.dart
+++ b/lib/add_edit_expense_screen.dart
@@ -18,6 +18,7 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
   final DatabaseHelper _dbHelper = DatabaseHelper();
   List<Map<String, dynamic>> categories = [];
   List<Map<String, dynamic>> expenses = [];
+  double _totalAmount = 0.0;
   String _filterOption = 'All';
   DateTime? _filterStartDate;
   DateTime? _filterEndDate;
@@ -65,8 +66,13 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
       ''',
       args,
     );
+    double sum = 0.0;
+    for (final row in data) {
+      sum += (row['amount'] as num?)?.toDouble() ?? 0.0;
+    }
     setState(() {
       expenses = data;
+      _totalAmount = sum;
     });
   }
 
@@ -117,6 +123,15 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
     }
 
     await _fetchExpenses(startDate: start, endDate: end);
+  }
+
+  void _resetFilter() {
+    setState(() {
+      _filterOption = 'All';
+      _filterStartDate = null;
+      _filterEndDate = null;
+    });
+    _applyFilter();
   }
 
   void _populateForm(Map<String, dynamic> expense) {
@@ -355,8 +370,22 @@ class _AddEditExpenseScreenState extends State<AddEditExpenseScreen> {
                             onPressed: _applyFilter,
                             child: const Text('Apply'),
                           ),
+                          TextButton(
+                            onPressed: _resetFilter,
+                            child: const Text('Reset'),
+                          ),
                         ],
                       ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'Total: Rs${_totalAmount.toStringAsFixed(2)}',
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                    ),
                   ],
                 ),
               ),

--- a/lib/database_helper.dart
+++ b/lib/database_helper.dart
@@ -90,13 +90,26 @@ class DatabaseHelper {
     return (result.first['total_amount'] as num?)?.toDouble() ?? 0.0;
   }
 
-  Future<List<Map<String, dynamic>>> queryExpensesByDate() async {
+  Future<List<Map<String, dynamic>>> queryExpensesByDate({
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
     final db = await database;
+    var whereClause = '';
+    final args = <dynamic>[];
+    if (startDate != null && endDate != null) {
+      whereClause = 'WHERE date(date) BETWEEN date(?) AND date(?)';
+      args.addAll([
+        startDate.toIso8601String(),
+        endDate.toIso8601String(),
+      ]);
+    }
     return await db.rawQuery('''
       SELECT date(date) AS date, SUM(amount) AS total_amount
       FROM expenses
+      $whereClause
       GROUP BY date(date)
       ORDER BY date(date)
-    ''');
+    ''', args);
   }
 }

--- a/lib/expenses_chart_screen.dart
+++ b/lib/expenses_chart_screen.dart
@@ -13,6 +13,9 @@ class ExpensesChartScreen extends StatefulWidget {
 class _ExpensesChartScreenState extends State<ExpensesChartScreen> {
   final DatabaseHelper _dbHelper = DatabaseHelper();
   List<Map<String, dynamic>> _dailyExpenses = [];
+  DateTime? _startDate;
+  DateTime? _endDate;
+  double _total = 0.0;
 
   @override
   void initState() {
@@ -20,11 +23,31 @@ class _ExpensesChartScreenState extends State<ExpensesChartScreen> {
     _fetchDailyExpenses();
   }
 
-  Future<void> _fetchDailyExpenses() async {
-    final data = await _dbHelper.queryExpensesByDate();
+  Future<void> _fetchDailyExpenses({DateTime? start, DateTime? end}) async {
+    final data = await _dbHelper.queryExpensesByDate(
+      startDate: start,
+      endDate: end,
+    );
+    double sum = 0.0;
+    for (final row in data) {
+      sum += (row['total_amount'] as num?)?.toDouble() ?? 0.0;
+    }
     setState(() {
       _dailyExpenses = data;
+      _total = sum;
     });
+  }
+
+  void _applyFilter() {
+    _fetchDailyExpenses(start: _startDate, end: _endDate);
+  }
+
+  void _resetFilter() {
+    setState(() {
+      _startDate = null;
+      _endDate = null;
+    });
+    _fetchDailyExpenses();
   }
 
   @override
@@ -46,46 +69,118 @@ class _ExpensesChartScreenState extends State<ExpensesChartScreen> {
       appBar: AppBar(title: const Text('Expenses Over Time')),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: _dailyExpenses.isEmpty
-            ? const Center(child: Text('No data'))
-            : BarChart(
-                BarChartData(
-                  barGroups: barGroups,
-                  gridData: FlGridData(show: false),
-                  titlesData: FlTitlesData(
-                    leftTitles: AxisTitles(
-                      sideTitles: SideTitles(
-                        showTitles: true,
-                        reservedSize: 40, // optional: give more width for large numbers
-                        getTitlesWidget: (double value, TitleMeta meta) {
-                          return SideTitleWidget(
-                            axisSide: meta.axisSide,
-                            space: 8,
-                            child: Text(
-                              NumberFormat.compact().format(value), // or just value.toStringAsFixed(0)
-                              style: const TextStyle(fontSize: 10),
-                            ),
-                          );
-                        },
-                      ),
-                    ),
-                    rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-                    topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-                    bottomTitles: AxisTitles(
-                      sideTitles: SideTitles(
-                        showTitles: true,
-                        getTitlesWidget: (double value, TitleMeta meta) {
-                          final label = labels[value.toInt()] ?? '';
-                          return SideTitleWidget(
-                            axisSide: meta.axisSide,
-                            child: Text(label, style: const TextStyle(fontSize: 10)),
-                          );
-                        },
-                      ),
-                    ),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                TextButton(
+                  onPressed: () async {
+                    final date = await showDatePicker(
+                      context: context,
+                      initialDate: _startDate ?? DateTime.now(),
+                      firstDate: DateTime(2000),
+                      lastDate: DateTime(2100),
+                    );
+                    if (date != null) {
+                      setState(() {
+                        _startDate = date;
+                      });
+                    }
+                  },
+                  child: Text(
+                    _startDate == null
+                        ? 'Start Date'
+                        : DateFormat('yyyy-MM-dd').format(_startDate!),
                   ),
                 ),
+                TextButton(
+                  onPressed: () async {
+                    final date = await showDatePicker(
+                      context: context,
+                      initialDate: _endDate ?? DateTime.now(),
+                      firstDate: DateTime(2000),
+                      lastDate: DateTime(2100),
+                    );
+                    if (date != null) {
+                      setState(() {
+                        _endDate = date;
+                      });
+                    }
+                  },
+                  child: Text(
+                    _endDate == null
+                        ? 'End Date'
+                        : DateFormat('yyyy-MM-dd').format(_endDate!),
+                  ),
+                ),
+                ElevatedButton(
+                  onPressed: _applyFilter,
+                  child: const Text('Apply'),
+                ),
+                TextButton(
+                  onPressed: _resetFilter,
+                  child: const Text('Reset'),
+                ),
+              ],
+            ),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 8.0),
+                child: Text(
+                  'Total: Rs${_total.toStringAsFixed(2)}',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
               ),
+            ),
+            Expanded(
+              child: _dailyExpenses.isEmpty
+                  ? const Center(child: Text('No data'))
+                  : BarChart(
+                      BarChartData(
+                        barGroups: barGroups,
+                        gridData: FlGridData(show: false),
+                        titlesData: FlTitlesData(
+                          leftTitles: AxisTitles(
+                            sideTitles: SideTitles(
+                              showTitles: true,
+                              reservedSize: 40,
+                              getTitlesWidget: (double value, TitleMeta meta) {
+                                return SideTitleWidget(
+                                  axisSide: meta.axisSide,
+                                  space: 8,
+                                  child: Text(
+                                    NumberFormat.compact().format(value),
+                                    style: const TextStyle(fontSize: 10),
+                                  ),
+                                );
+                              },
+                            ),
+                          ),
+                          rightTitles: const AxisTitles(
+                              sideTitles: SideTitles(showTitles: false)),
+                          topTitles: const AxisTitles(
+                              sideTitles: SideTitles(showTitles: false)),
+                          bottomTitles: AxisTitles(
+                            sideTitles: SideTitles(
+                              showTitles: true,
+                              getTitlesWidget: (double value, TitleMeta meta) {
+                                final label = labels[value.toInt()] ?? '';
+                                return SideTitleWidget(
+                                  axisSide: meta.axisSide,
+                                  child:
+                                      Text(label, style: const TextStyle(fontSize: 10)),
+                                );
+                              },
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- keep date filter controls visible even when there's no data
- add `date()` around range parameters to correctly filter daily expenses
- reset buttons so users can clear selected date ranges

## Testing
- `dart --version` *(fails: command not found)*
- `dart format lib/*.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a03184cc08323aa980792a1d04c4b