### PR TITLE
Fix duplicate category name crash on update

### DIFF
--- a/lib/manage_categories_screen.dart
+++ b/lib/manage_categories_screen.dart
@@ -45,12 +45,18 @@ class _ManageCategoriesScreenState extends State<ManageCategoriesScreen> {
         );
       }
     } else {
-      await _dbHelper.update(
-        'categories',
-        {'name': name},
-        'id = ?',
-        [_selectedCategoryId],
-      );
+      try {
+        await _dbHelper.update(
+          'categories',
+          {'name': name},
+          'id = ?',
+          [_selectedCategoryId],
+        );
+      } catch (e) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Category "$name" already exists!')),
+        );
+      }
     }
     _fetchCategories();
     _categoryController.clear();


### PR DESCRIPTION
## Summary
- handle uniqueness errors when updating category names

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6872089ea4908327a39abea881b13cc5