### PR TITLE
Add tooltip on bar tap

### DIFF
--- a/lib/expenses_chart_screen.dart
+++ b/lib/expenses_chart_screen.dart
@@ -142,6 +142,34 @@ class _ExpensesChartScreenState extends State<ExpensesChartScreen> {
                     BarChartData(
                       barGroups: barGroups,
                       gridData: FlGridData(show: false),
+                      barTouchData: BarTouchData(
+                        enabled: true,
+                        touchTooltipData: BarTouchTooltipData(
+                          tooltipBgColor: Colors.black54,
+                          getTooltipItem: (
+                            BarChartGroupData group,
+                            int groupIndex,
+                            BarChartRodData rod,
+                            int rodIndex,
+                          ) {
+                            final label = labels[group.x.toInt()] ?? '';
+                            return BarTooltipItem(
+                              '$label\n',
+                              const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                              ),
+                              children: [
+                                TextSpan(
+                                  text:
+                                      'Rs${rod.toY.toStringAsFixed(2)}',
+                                  style: const TextStyle(color: Colors.white),
+                                ),
+                              ],
+                            );
+                          },
+                        ),
+                      ),
                       titlesData: FlTitlesData(
                         leftTitles: AxisTitles(
                           sideTitles: SideTitles(


### PR DESCRIPTION
## Summary
- show amount and date in a tooltip when tapping on chart bars

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687246c50e688327ad285c4a7a6549ac